### PR TITLE
Fix default logo

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     build: https://github.com/unifiedstreaming/live-demo.git#:ffmpeg
     environment:
       - PUB_POINT_URI=http://live-origin/test/test.isml/Streams(ffmpeg)
-      - LOGO_OVERLAY=https://raw.githubusercontent.com/unifiedstreaming/live-demo/master/ffmpeg/usp_logo_white.png
+      - LOGO_OVERLAY=
     depends_on:
       live-origin:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     build: https://github.com/unifiedstreaming/live-demo.git#:ffmpeg
     environment:
       - PUB_POINT_URI=http://live-origin/test/test.isml/Streams(ffmpeg)
-      - LOGO_OVERLAY=
+      - LOGO_OVERLAY=https://raw.githubusercontent.com/unifiedstreaming/live-demo/master/ffmpeg/usp_logo_white.png
     depends_on:
       live-origin:
         condition: service_healthy

--- a/ffmpeg/entrypoint.sh
+++ b/ffmpeg/entrypoint.sh
@@ -36,5 +36,5 @@ if [ ! $PUB_POINT_URI ]
   exit 1
 fi
 
-
 exec "$@"
+

--- a/ffmpeg/entrypoint.sh
+++ b/ffmpeg/entrypoint.sh
@@ -18,7 +18,7 @@ if [ $FRAME_RATE == "30000/1001" ] || [ $FRAME_RATE == "60000/1001" ]
   export FRAME_SEP=\.
 fi
 
-if [ -z ${LOGO_OVERLAY+x$LOGO_OVERLAY} ]
+if [ -z ${LOGO_OVERLAY} ]
   then
   export LOGO_OVERLAY="https://raw.githubusercontent.com/unifiedstreaming/live-demo/master/ffmpeg/usp_logo_white.png"
 fi


### PR DESCRIPTION
Currently the default configuration does not use the USP logo as written in the instructions. 

`if [ -z ${LOGO_OVERLAY+x$LOGO_OVERLAY} ]`

this will always result to False and should be changed to: 

`if [ -z ${LOGO_OVERLAY} ]`